### PR TITLE
Modernize support for calc() CSS function

### DIFF
--- a/layout/style/CSSCalc.h
+++ b/layout/style/CSSCalc.h
@@ -318,11 +318,7 @@ SerializeCalcInternal(const typename CalcOps::input_type& aValue, CalcOps &aOps)
     if (needParens) {
       aOps.Append("(");
     }
-    if (unit == eCSSUnit_Calc_Times_L) {
-      aOps.AppendNumber(array->Item(0));
-    } else {
-      SerializeCalcInternal(array->Item(0), aOps);
-    }
+    SerializeCalcInternal(array->Item(0), aOps);
     if (needParens) {
       aOps.Append(")");
     }
@@ -340,11 +336,7 @@ SerializeCalcInternal(const typename CalcOps::input_type& aValue, CalcOps &aOps)
     if (needParens) {
       aOps.Append("(");
     }
-    if (unit == eCSSUnit_Calc_Times_L) {
-      SerializeCalcInternal(array->Item(1), aOps);
-    } else {
-      aOps.AppendNumber(array->Item(1));
-    }
+    SerializeCalcInternal(array->Item(1), aOps);
     if (needParens) {
       aOps.Append(")");
     }

--- a/layout/style/CSSStyleSheet.cpp
+++ b/layout/style/CSSStyleSheet.cpp
@@ -161,7 +161,8 @@ nsMediaExpression::Matches(nsPresContext *aPresContext,
     case nsMediaFeature::eLength:
       {
         NS_ASSERTION(actual.IsLengthUnit(), "bad actual value");
-        NS_ASSERTION(required.IsLengthUnit(), "bad required value");
+        NS_ASSERTION(required.IsLengthUnit() || required.IsCalcUnit(),
+                     "bad required value");
         nscoord actualCoord = nsRuleNode::CalcLengthWithInitialFont(
                                 aPresContext, actual);
         nscoord requiredCoord = nsRuleNode::CalcLengthWithInitialFont(
@@ -490,7 +491,8 @@ nsMediaQuery::AppendToString(nsAString& aString) const
       aString.AppendLiteral(": ");
       switch (feature->mValueType) {
         case nsMediaFeature::eLength:
-          NS_ASSERTION(expr.mValue.IsLengthUnit(), "bad unit");
+          NS_ASSERTION(expr.mValue.IsLengthUnit() || expr.mValue.IsCalcUnit(),
+                       "bad unit");
           // Use 'width' as a property that takes length values
           // written in the normal way.
           expr.mValue.AppendToString(eCSSProperty_width, aString,

--- a/layout/style/CSSStyleSheet.cpp
+++ b/layout/style/CSSStyleSheet.cpp
@@ -130,6 +130,106 @@ int32_t DoCompare(Numeric a, Numeric b)
   return 1;
 }
 
+struct MediaQueryTypedCalcLengthResult
+{
+  double mValue;
+  int32_t mExponent;
+};
+
+static bool
+EvaluateMediaQueryTypedCalcLength(nsPresContext* aPresContext,
+                                  const nsCSSValue& aValue,
+                                  MediaQueryTypedCalcLengthResult& aResult)
+{
+  switch (aValue.GetUnit()) {
+    case eCSSUnit_Calc: {
+      nsCSSValue::Array* array = aValue.GetArrayValue();
+      MOZ_ASSERT(array->Count() == 1, "unexpected length");
+      return EvaluateMediaQueryTypedCalcLength(aPresContext, array->Item(0),
+                                               aResult);
+    }
+
+    case eCSSUnit_Calc_Plus:
+    case eCSSUnit_Calc_Minus: {
+      nsCSSValue::Array* array = aValue.GetArrayValue();
+      MOZ_ASSERT(array->Count() == 2, "unexpected length");
+      MediaQueryTypedCalcLengthResult lhs;
+      MediaQueryTypedCalcLengthResult rhs;
+      if (!EvaluateMediaQueryTypedCalcLength(aPresContext, array->Item(0), lhs) ||
+          !EvaluateMediaQueryTypedCalcLength(aPresContext, array->Item(1), rhs) ||
+          lhs.mExponent != rhs.mExponent) {
+        return false;
+      }
+      aResult.mExponent = lhs.mExponent;
+      aResult.mValue = aValue.GetUnit() == eCSSUnit_Calc_Plus
+                         ? lhs.mValue + rhs.mValue
+                         : lhs.mValue - rhs.mValue;
+      return true;
+    }
+
+    case eCSSUnit_Calc_Times_L:
+    case eCSSUnit_Calc_Times_R:
+    case eCSSUnit_Calc_Divided: {
+      nsCSSValue::Array* array = aValue.GetArrayValue();
+      MOZ_ASSERT(array->Count() == 2, "unexpected length");
+      MediaQueryTypedCalcLengthResult lhs;
+      MediaQueryTypedCalcLengthResult rhs;
+      if (!EvaluateMediaQueryTypedCalcLength(aPresContext, array->Item(0), lhs) ||
+          !EvaluateMediaQueryTypedCalcLength(aPresContext, array->Item(1), rhs)) {
+        return false;
+      }
+      if (aValue.GetUnit() == eCSSUnit_Calc_Divided) {
+        if (rhs.mValue == 0.0) {
+          return false;
+        }
+        aResult.mValue = lhs.mValue / rhs.mValue;
+        aResult.mExponent = lhs.mExponent - rhs.mExponent;
+      } else {
+        aResult.mValue = lhs.mValue * rhs.mValue;
+        aResult.mExponent = lhs.mExponent + rhs.mExponent;
+      }
+      return true;
+    }
+
+    case eCSSUnit_Number:
+      aResult.mValue = aValue.GetFloatValue();
+      aResult.mExponent = 0;
+      return true;
+
+    default:
+      break;
+  }
+
+  if (!aValue.IsLengthUnit()) {
+    return false;
+  }
+
+  aResult.mValue = double(nsRuleNode::CalcLengthWithInitialFont(aPresContext,
+                                                                aValue));
+  aResult.mExponent = 1;
+  return true;
+}
+
+static bool
+ComputeMediaQueryTypedCalcLength(nsPresContext* aPresContext,
+                                 const nsCSSValue& aValue,
+                                 nscoord& aResult)
+{
+  if (aValue.IsLengthUnit()) {
+    aResult = nsRuleNode::CalcLengthWithInitialFont(aPresContext, aValue);
+    return true;
+  }
+
+  MediaQueryTypedCalcLengthResult result;
+  if (!EvaluateMediaQueryTypedCalcLength(aPresContext, aValue, result) ||
+      result.mExponent != 1) {
+    return false;
+  }
+
+  aResult = NSToCoordFloorClamped(result.mValue);
+  return true;
+}
+
 bool
 nsMediaExpression::Matches(nsPresContext *aPresContext,
                            const nsCSSValue& aActualValue) const
@@ -165,8 +265,11 @@ nsMediaExpression::Matches(nsPresContext *aPresContext,
                      "bad required value");
         nscoord actualCoord = nsRuleNode::CalcLengthWithInitialFont(
                                 aPresContext, actual);
-        nscoord requiredCoord = nsRuleNode::CalcLengthWithInitialFont(
-                                  aPresContext, required);
+        nscoord requiredCoord;
+        if (!ComputeMediaQueryTypedCalcLength(aPresContext, required,
+                                              requiredCoord)) {
+          return false;
+        }
         cmp = DoCompare(actualCoord, requiredCoord);
       }
       break;

--- a/layout/style/nsCSSParser.cpp
+++ b/layout/style/nsCSSParser.cpp
@@ -170,6 +170,153 @@ struct ReducePercentageCalcOps : ReduceNumberCalcOps
   }
 };
 
+struct ReduceDimensionCalcOps : public mozilla::css::BasicFloatCalcOps,
+                                public mozilla::css::CSSValueInputCalcOps,
+                                public mozilla::css::NumbersAlreadyNormalizedOps
+{
+  enum class DimensionType {
+    Angle,
+    Time,
+    Frequency,
+  };
+
+  explicit ReduceDimensionCalcOps(DimensionType aDimensionType)
+    : mDimensionType(aDimensionType)
+  {
+  }
+
+  result_type ComputeLeafValue(const nsCSSValue& aValue)
+  {
+    switch (mDimensionType) {
+      case DimensionType::Angle:
+        MOZ_ASSERT(aValue.IsAngularUnit(), "unexpected unit");
+        return aValue.GetAngleValueInDegrees();
+
+      case DimensionType::Time:
+        MOZ_ASSERT(aValue.IsTimeUnit(), "unexpected unit");
+        return aValue.GetUnit() == eCSSUnit_Seconds
+                 ? aValue.GetFloatValue()
+                 : aValue.GetFloatValue() / float(PR_MSEC_PER_SEC);
+
+      case DimensionType::Frequency:
+        MOZ_ASSERT(aValue.IsFrequencyUnit(), "unexpected unit");
+        return aValue.GetUnit() == eCSSUnit_Kilohertz
+                 ? aValue.GetFloatValue() * 1000.0f
+                 : aValue.GetFloatValue();
+    }
+
+    MOZ_ASSERT_UNREACHABLE("unexpected dimension type");
+    return 0.0f;
+  }
+
+  DimensionType mDimensionType;
+};
+
+static uint32_t
+GetCalcParseVariantMask(uint32_t aVariantMask)
+{
+  uint32_t calcVariantMask = 0;
+
+  if (aVariantMask & VARIANT_LENGTH) {
+    calcVariantMask |= VARIANT_LENGTH | (aVariantMask & VARIANT_ABSOLUTE_DIMENSION);
+  }
+  if (aVariantMask & VARIANT_PERCENT) {
+    calcVariantMask |= VARIANT_PERCENT;
+  }
+  if (aVariantMask & VARIANT_ANGLE) {
+    calcVariantMask |= VARIANT_ANGLE;
+  }
+  if (aVariantMask & VARIANT_TIME) {
+    calcVariantMask |= VARIANT_TIME;
+  }
+  if (aVariantMask & VARIANT_FREQUENCY) {
+    calcVariantMask |= VARIANT_FREQUENCY;
+  }
+  if (aVariantMask & (VARIANT_NUMBER | VARIANT_INTEGER)) {
+    calcVariantMask |= VARIANT_NUMBER;
+  }
+  if (aVariantMask & VARIANT_OPACITY) {
+    calcVariantMask |= VARIANT_PN;
+  }
+
+  return calcVariantMask;
+}
+
+static bool
+ShouldPreserveCalcValue(uint32_t aVariantMask)
+{
+  return (aVariantMask & VARIANT_LENGTH) != 0 ||
+         ((aVariantMask & VARIANT_PERCENT) != 0 &&
+          (aVariantMask & (VARIANT_NUMBER | VARIANT_INTEGER |
+                           VARIANT_OPACITY)) == 0);
+}
+
+static int32_t
+RoundFloatToCSSInteger(float aValue)
+{
+  double rounded = std::floor(double(aValue) + 0.5);
+  rounded = mozilla::clamped(
+    rounded,
+    double(std::numeric_limits<int32_t>::min()),
+    double(std::numeric_limits<int32_t>::max()));
+  return int32_t(rounded);
+}
+
+static bool
+NormalizeCalcForVariant(nsCSSValue& aValue,
+                        uint32_t aPropertyVariantMask,
+                        uint32_t aResultVariantMask)
+{
+  if (ShouldPreserveCalcValue(aPropertyVariantMask)) {
+    return true;
+  }
+
+  if (aResultVariantMask == VARIANT_NUMBER) {
+    ReduceNumberCalcOps ops;
+    float value = mozilla::css::ComputeCalc(aValue, ops);
+
+    if (aPropertyVariantMask & VARIANT_INTEGER) {
+      aValue.SetIntValue(RoundFloatToCSSInteger(value), eCSSUnit_Integer);
+    } else {
+      aValue.SetFloatValue(value, eCSSUnit_Number);
+    }
+    return true;
+  }
+
+  if (aResultVariantMask & VARIANT_PERCENT) {
+    ReducePercentageCalcOps ops;
+    float value = mozilla::css::ComputeCalc(aValue, ops);
+
+    if (aPropertyVariantMask & VARIANT_OPACITY) {
+      aValue.SetFloatValue(value, eCSSUnit_Number);
+    } else {
+      aValue.SetPercentValue(value);
+    }
+    return true;
+  }
+
+  if (aResultVariantMask & VARIANT_ANGLE) {
+    ReduceDimensionCalcOps ops(ReduceDimensionCalcOps::DimensionType::Angle);
+    aValue.SetFloatValue(mozilla::css::ComputeCalc(aValue, ops), eCSSUnit_Degree);
+    return true;
+  }
+
+  if (aResultVariantMask & VARIANT_TIME) {
+    ReduceDimensionCalcOps ops(ReduceDimensionCalcOps::DimensionType::Time);
+    aValue.SetFloatValue(mozilla::css::ComputeCalc(aValue, ops), eCSSUnit_Seconds);
+    return true;
+  }
+
+  if (aResultVariantMask & VARIANT_FREQUENCY) {
+    ReduceDimensionCalcOps ops(ReduceDimensionCalcOps::DimensionType::Frequency);
+    aValue.SetFloatValue(mozilla::css::ComputeCalc(aValue, ops), eCSSUnit_Hertz);
+    return true;
+  }
+
+  MOZ_ASSERT_UNREACHABLE("unsupported calc result type");
+  return false;
+}
+
 static_assert(css::eAuthorSheetFeatures == 0 &&
               css::eUserSheetFeatures == 1 &&
               css::eAgentSheetFeatures == 2,
@@ -979,7 +1126,8 @@ protected:
   bool ParseBorderStyle();
   bool ParseBorderWidth();
 
-  bool ParseCalc(nsCSSValue &aValue, uint32_t aVariantMask);
+  bool ParseCalc(nsCSSValue& aValue, uint32_t aVariantMask,
+                 uint32_t* aResultVariantMask = nullptr);
   bool ParseCalcAdditiveExpression(nsCSSValue& aValue,
                                    uint32_t& aVariantMask);
   bool ParseCalcMultiplicativeExpression(nsCSSValue& aValue,
@@ -8577,14 +8725,18 @@ CSSParserImpl::ParseNonNegativeVariant(nsCSSValue& aValue,
                                VARIANT_NUMBER |
                                VARIANT_LENGTH |
                                VARIANT_PERCENT |
+                               VARIANT_FREQUENCY |
                                VARIANT_OPACITY |
+                               VARIANT_TIME |
                                VARIANT_INTEGER)) == 0,
              "need to update code below to handle additional variants");
 
   CSSParseResult result = ParseVariant(aValue, aVariantMask, aKeywordTable);
   if (result == CSSParseResult::Ok) {
     if (eCSSUnit_Number == aValue.GetUnit() ||
-        aValue.IsLengthUnit()){
+        aValue.IsLengthUnit() ||
+        aValue.IsFrequencyUnit() ||
+        aValue.IsTimeUnit()) {
       if (aValue.GetFloatValue() < 0) {
         UngetToken();
         return CSSParseResult::NotFound;
@@ -8946,12 +9098,14 @@ CSSParserImpl::ParseVariant(nsCSSValue& aValue,
       return CSSParseResult::Ok;
     }
   }
-  if ((aVariantMask & VARIANT_CALC) &&
+  uint32_t calcVariantMask = GetCalcParseVariantMask(aVariantMask);
+  if (calcVariantMask &&
+      (((aVariantMask & VARIANT_CALC) != 0) ||
+       !ShouldPreserveCalcValue(calcVariantMask)) &&
       IsCalcFunctionToken(*tk)) {
-    // calc() currently allows only lengths and percents and number inside it.
-    // And note that in current implementation, number cannot be mixed with
-    // length and percent.
-    if (!ParseCalc(aValue, aVariantMask & VARIANT_LPN)) {
+    uint32_t calcResultVariantMask = calcVariantMask;
+    if (!ParseCalc(aValue, calcVariantMask, &calcResultVariantMask) ||
+        !NormalizeCalcForVariant(aValue, aVariantMask, calcResultVariantMask)) {
       return CSSParseResult::Error;
     }
     return CSSParseResult::Ok;
@@ -14671,7 +14825,8 @@ CSSParserImpl::ParseBorderColors(nsCSSPropertyID aProperty)
 
 // Parse the top level of a calc() expression.
 bool
-CSSParserImpl::ParseCalc(nsCSSValue &aValue, uint32_t aVariantMask)
+CSSParserImpl::ParseCalc(nsCSSValue& aValue, uint32_t aVariantMask,
+                         uint32_t* aResultVariantMask)
 {
   // Parsing calc expressions requires, in a number of cases, looking
   // for a token that is *either* a value of the property or a number.
@@ -14686,14 +14841,18 @@ CSSParserImpl::ParseCalc(nsCSSValue &aValue, uint32_t aVariantMask)
   do {
     // The toplevel of a calc() is always an nsCSSValue::Array of length 1.
     RefPtr<nsCSSValue::Array> arr = nsCSSValue::Array::Create(1);
+    uint32_t resultVariantMask = aVariantMask;
 
-    if (!ParseCalcAdditiveExpression(arr->Item(0), aVariantMask))
+    if (!ParseCalcAdditiveExpression(arr->Item(0), resultVariantMask))
       break;
 
     if (!ExpectSymbol(')', true))
       break;
 
     aValue.SetArrayValue(arr, eCSSUnit_Calc);
+    if (aResultVariantMask) {
+      *aResultVariantMask = resultVariantMask;
+    }
     mUnitlessLengthQuirk = oldUnitlessLengthQuirk;
     return true;
   } while (false);

--- a/layout/style/nsCSSParser.cpp
+++ b/layout/style/nsCSSParser.cpp
@@ -263,6 +263,49 @@ RoundFloatToCSSInteger(float aValue)
 }
 
 static bool
+IsCalcSpecialNumberIdent(const nsAString& aIdent, float& aValue)
+{
+  if (aIdent.LowerCaseEqualsLiteral("nan")) {
+    aValue = std::numeric_limits<float>::quiet_NaN();
+    return true;
+  }
+
+  if (aIdent.LowerCaseEqualsLiteral("infinity")) {
+    aValue = std::numeric_limits<float>::infinity();
+    return true;
+  }
+
+  if (aIdent.LowerCaseEqualsLiteral("-infinity")) {
+    aValue = -std::numeric_limits<float>::infinity();
+    return true;
+  }
+
+  return false;
+}
+
+static bool
+IsCalcNumberFunctionName(const nsAString& aIdent)
+{
+  return aIdent.LowerCaseEqualsLiteral("min") ||
+         aIdent.LowerCaseEqualsLiteral("max") ||
+         aIdent.LowerCaseEqualsLiteral("clamp");
+}
+
+static void
+WrapCalcNumberValue(nsCSSValue& aValue, float aNumber)
+{
+  RefPtr<nsCSSValue::Array> arr = nsCSSValue::Array::Create(1);
+  arr->Item(0).SetFloatValue(aNumber, eCSSUnit_Number);
+  aValue.SetArrayValue(arr, eCSSUnit_Calc);
+}
+
+static bool
+IsFiniteCalcNumber(float aValue)
+{
+  return !std::isnan(aValue) && !std::isinf(aValue);
+}
+
+static bool
 GetCalcLengthTypedArithmeticExponent(const nsCSSValue& aValue,
                                      int32_t& aExponent)
 {
@@ -324,7 +367,8 @@ GetCalcLengthTypedArithmeticExponent(const nsCSSValue& aValue,
 static bool
 NormalizeCalcForVariant(nsCSSValue& aValue,
                         uint32_t aPropertyVariantMask,
-                        uint32_t aResultVariantMask)
+                        uint32_t aResultVariantMask,
+                        bool aSawSpecialNumericValues = false)
 {
   if (ShouldPreserveCalcValue(aPropertyVariantMask)) {
     return true;
@@ -335,7 +379,13 @@ NormalizeCalcForVariant(nsCSSValue& aValue,
     float value = mozilla::css::ComputeCalc(aValue, ops);
 
     if (aPropertyVariantMask & VARIANT_INTEGER) {
+      if (!IsFiniteCalcNumber(value)) {
+        return false;
+      }
       aValue.SetIntValue(RoundFloatToCSSInteger(value), eCSSUnit_Integer);
+    } else if ((aPropertyVariantMask & VARIANT_OPACITY) &&
+               aSawSpecialNumericValues) {
+      WrapCalcNumberValue(aValue, value);
     } else {
       aValue.SetFloatValue(value, eCSSUnit_Number);
     }
@@ -347,7 +397,11 @@ NormalizeCalcForVariant(nsCSSValue& aValue,
     float value = mozilla::css::ComputeCalc(aValue, ops);
 
     if (aPropertyVariantMask & VARIANT_OPACITY) {
-      aValue.SetFloatValue(value, eCSSUnit_Number);
+      if (aSawSpecialNumericValues) {
+        WrapCalcNumberValue(aValue, value);
+      } else {
+        aValue.SetFloatValue(value, eCSSUnit_Number);
+      }
     } else {
       aValue.SetPercentValue(value);
     }
@@ -1186,13 +1240,16 @@ protected:
   bool ParseBorderWidth();
 
   bool ParseCalc(nsCSSValue& aValue, uint32_t aVariantMask,
-                 uint32_t* aResultVariantMask = nullptr);
+                 uint32_t* aResultVariantMask = nullptr,
+                 bool* aSawSpecialNumericValues = nullptr);
   bool ParseCalcAdditiveExpression(nsCSSValue& aValue,
                                    uint32_t& aVariantMask);
   bool ParseCalcMultiplicativeExpression(nsCSSValue& aValue,
                                          uint32_t& aVariantMask,
                                          bool *aHadFinalWS);
   bool ParseCalcTerm(nsCSSValue& aValue, uint32_t& aVariantMask);
+  bool ParseCalcNumberExpressionValue(float& aValue);
+  bool ParseCalcNumberFunction(nsCSSValue& aValue, uint32_t& aVariantMask);
   bool RequireWhitespace();
 
   // For "flex" shorthand property, defined in CSS Flexbox spec
@@ -1787,6 +1844,7 @@ protected:
   // out of the parser.
   bool mSheetPrincipalRequired;
   bool mCalcAllowsTypedArithmetic;
+  bool mCalcHasSpecialNumericValues;
 
   // This enum helps us track whether we've unprefixed "display: -webkit-box"
   // (treating it as "display: flex") in an earlier declaration within a series
@@ -1892,6 +1950,7 @@ CSSParserImpl::CSSParserImpl()
     mSuppressErrors(false),
     mSheetPrincipalRequired(true),
     mCalcAllowsTypedArithmetic(false),
+    mCalcHasSpecialNumericValues(false),
     mWebkitBoxUnprefixState(eNotParsingDecls),
     mNextFree(nullptr)
 {
@@ -9169,8 +9228,11 @@ CSSParserImpl::ParseVariant(nsCSSValue& aValue,
        !ShouldPreserveCalcValue(calcVariantMask)) &&
       IsCalcFunctionToken(*tk)) {
     uint32_t calcResultVariantMask = calcVariantMask;
-    if (!ParseCalc(aValue, calcVariantMask, &calcResultVariantMask) ||
-        !NormalizeCalcForVariant(aValue, aVariantMask, calcResultVariantMask)) {
+    bool sawSpecialNumericValues = false;
+    if (!ParseCalc(aValue, calcVariantMask, &calcResultVariantMask,
+                   &sawSpecialNumericValues) ||
+        !NormalizeCalcForVariant(aValue, aVariantMask, calcResultVariantMask,
+                                 sawSpecialNumericValues)) {
       return CSSParseResult::Error;
     }
     return CSSParseResult::Ok;
@@ -14891,7 +14953,8 @@ CSSParserImpl::ParseBorderColors(nsCSSPropertyID aProperty)
 // Parse the top level of a calc() expression.
 bool
 CSSParserImpl::ParseCalc(nsCSSValue& aValue, uint32_t aVariantMask,
-                         uint32_t* aResultVariantMask)
+                         uint32_t* aResultVariantMask,
+                         bool* aSawSpecialNumericValues)
 {
   // Parsing calc expressions requires, in a number of cases, looking
   // for a token that is *either* a value of the property or a number.
@@ -14900,7 +14963,9 @@ CSSParserImpl::ParseCalc(nsCSSValue& aValue, uint32_t aVariantMask,
   MOZ_ASSERT(aVariantMask != 0, "unexpected variant mask");
 
   bool oldUnitlessLengthQuirk = mUnitlessLengthQuirk;
+  bool oldCalcHasSpecialNumericValues = mCalcHasSpecialNumericValues;
   mUnitlessLengthQuirk = false;
+  mCalcHasSpecialNumericValues = false;
 
   // One-iteration loop so we can break to the error-handling case.
   do {
@@ -14937,11 +15002,21 @@ CSSParserImpl::ParseCalc(nsCSSValue& aValue, uint32_t aVariantMask,
     if (aResultVariantMask) {
       *aResultVariantMask = resultVariantMask;
     }
+    if (aSawSpecialNumericValues) {
+      *aSawSpecialNumericValues = mCalcHasSpecialNumericValues;
+    }
+    mCalcHasSpecialNumericValues =
+      oldCalcHasSpecialNumericValues || mCalcHasSpecialNumericValues;
     mUnitlessLengthQuirk = oldUnitlessLengthQuirk;
     return true;
   } while (false);
 
   SkipUntil(')');
+  if (aSawSpecialNumericValues) {
+    *aSawSpecialNumericValues = mCalcHasSpecialNumericValues;
+  }
+  mCalcHasSpecialNumericValues =
+    oldCalcHasSpecialNumericValues || mCalcHasSpecialNumericValues;
   mUnitlessLengthQuirk = oldUnitlessLengthQuirk;
   return false;
 }
@@ -15142,6 +15217,24 @@ CSSParserImpl::ParseCalcTerm(nsCSSValue& aValue, uint32_t& aVariantMask)
     }
     return true;
   }
+  if (mToken.mType == eCSSToken_Function &&
+      IsCalcNumberFunctionName(mToken.mIdent)) {
+    if (!ParseCalcNumberFunction(aValue, aVariantMask)) {
+      SkipUntil(')');
+      return false;
+    }
+    return true;
+  }
+  if ((aVariantMask & VARIANT_NUMBER) != 0 &&
+      mToken.mType == eCSSToken_Ident) {
+    float specialValue;
+    if (IsCalcSpecialNumberIdent(mToken.mIdent, specialValue)) {
+      mCalcHasSpecialNumericValues = true;
+      aValue.SetFloatValue(specialValue, eCSSUnit_Number);
+      aVariantMask = VARIANT_NUMBER;
+      return true;
+    }
+  }
   // ... or just a value
   UngetToken();
   // Always pass VARIANT_NUMBER to ParseVariant so that unitless zero
@@ -15163,6 +15256,82 @@ CSSParserImpl::ParseCalcTerm(nsCSSValue& aValue, uint32_t& aVariantMask)
       aVariantMask &= ~int32_t(VARIANT_NUMBER);
     }
   }
+  return true;
+}
+
+bool
+CSSParserImpl::ParseCalcNumberExpressionValue(float& aValue)
+{
+  nsCSSValue expression;
+  uint32_t variantMask = VARIANT_NUMBER;
+  if (!ParseCalcAdditiveExpression(expression, variantMask) ||
+      variantMask != VARIANT_NUMBER) {
+    return false;
+  }
+
+  ReduceNumberCalcOps ops;
+  aValue = mozilla::css::ComputeCalc(expression, ops);
+  return true;
+}
+
+bool
+CSSParserImpl::ParseCalcNumberFunction(nsCSSValue& aValue,
+                                       uint32_t& aVariantMask)
+{
+  MOZ_ASSERT(mToken.mType == eCSSToken_Function, "expected function token");
+  MOZ_ASSERT(IsCalcNumberFunctionName(mToken.mIdent),
+             "unexpected calc() number function");
+
+  float result;
+
+  if (mToken.mIdent.LowerCaseEqualsLiteral("clamp")) {
+    float minValue;
+    float centerValue;
+    float maxValue;
+    if (!ParseCalcNumberExpressionValue(minValue) ||
+        !ExpectSymbol(',', true) ||
+        !ParseCalcNumberExpressionValue(centerValue) ||
+        !ExpectSymbol(',', true) ||
+        !ParseCalcNumberExpressionValue(maxValue) ||
+        !ExpectSymbol(')', true)) {
+      return false;
+    }
+
+    if (std::isnan(minValue) || std::isnan(centerValue) ||
+        std::isnan(maxValue)) {
+      result = std::numeric_limits<float>::quiet_NaN();
+    } else {
+      result = std::max(minValue, std::min(centerValue, maxValue));
+    }
+  } else {
+    const bool isMax = mToken.mIdent.LowerCaseEqualsLiteral("max");
+    bool sawComma = false;
+
+    if (!ParseCalcNumberExpressionValue(result)) {
+      return false;
+    }
+
+    while (ExpectSymbol(',', true)) {
+      sawComma = true;
+      float candidate;
+      if (!ParseCalcNumberExpressionValue(candidate)) {
+        return false;
+      }
+      if (std::isnan(result) || std::isnan(candidate)) {
+        result = std::numeric_limits<float>::quiet_NaN();
+      } else {
+        result = isMax ? std::max(result, candidate)
+                       : std::min(result, candidate);
+      }
+    }
+
+    if (!sawComma || !ExpectSymbol(')', true)) {
+      return false;
+    }
+  }
+
+  aValue.SetFloatValue(result, eCSSUnit_Number);
+  aVariantMask = VARIANT_NUMBER;
   return true;
 }
 

--- a/layout/style/nsCSSParser.cpp
+++ b/layout/style/nsCSSParser.cpp
@@ -4005,7 +4005,7 @@ CSSParserImpl::ParseMediaQueryExpression(nsMediaQuery* aQuery)
   bool rv = false;
   switch (feature->mValueType) {
     case nsMediaFeature::eLength:
-      rv = ParseSingleTokenNonNegativeVariant(expr->mValue, VARIANT_LENGTH,
+      rv = ParseSingleTokenNonNegativeVariant(expr->mValue, VARIANT_LCALC,
                                               nullptr);
       break;
     case nsMediaFeature::eInteger:

--- a/layout/style/nsCSSParser.cpp
+++ b/layout/style/nsCSSParser.cpp
@@ -263,6 +263,65 @@ RoundFloatToCSSInteger(float aValue)
 }
 
 static bool
+GetCalcLengthTypedArithmeticExponent(const nsCSSValue& aValue,
+                                     int32_t& aExponent)
+{
+  switch (aValue.GetUnit()) {
+    case eCSSUnit_Calc: {
+      nsCSSValue::Array* array = aValue.GetArrayValue();
+      MOZ_ASSERT(array->Count() == 1, "unexpected length");
+      return GetCalcLengthTypedArithmeticExponent(array->Item(0), aExponent);
+    }
+
+    case eCSSUnit_Calc_Plus:
+    case eCSSUnit_Calc_Minus: {
+      nsCSSValue::Array* array = aValue.GetArrayValue();
+      MOZ_ASSERT(array->Count() == 2, "unexpected length");
+      int32_t lhsExponent;
+      int32_t rhsExponent;
+      if (!GetCalcLengthTypedArithmeticExponent(array->Item(0), lhsExponent) ||
+          !GetCalcLengthTypedArithmeticExponent(array->Item(1), rhsExponent) ||
+          lhsExponent != rhsExponent) {
+        return false;
+      }
+      aExponent = lhsExponent;
+      return true;
+    }
+
+    case eCSSUnit_Calc_Times_L:
+    case eCSSUnit_Calc_Times_R:
+    case eCSSUnit_Calc_Divided: {
+      nsCSSValue::Array* array = aValue.GetArrayValue();
+      MOZ_ASSERT(array->Count() == 2, "unexpected length");
+      int32_t lhsExponent;
+      int32_t rhsExponent;
+      if (!GetCalcLengthTypedArithmeticExponent(array->Item(0), lhsExponent) ||
+          !GetCalcLengthTypedArithmeticExponent(array->Item(1), rhsExponent)) {
+        return false;
+      }
+      aExponent = aValue.GetUnit() == eCSSUnit_Calc_Divided
+                    ? lhsExponent - rhsExponent
+                    : lhsExponent + rhsExponent;
+      return true;
+    }
+
+    case eCSSUnit_Number:
+      aExponent = 0;
+      return true;
+
+    default:
+      break;
+  }
+
+  if (aValue.IsLengthUnit()) {
+    aExponent = 1;
+    return true;
+  }
+
+  return false;
+}
+
+static bool
 NormalizeCalcForVariant(nsCSSValue& aValue,
                         uint32_t aPropertyVariantMask,
                         uint32_t aResultVariantMask)
@@ -1727,6 +1786,7 @@ protected:
   // not be set to false if any nsCSSValues created during parsing can escape
   // out of the parser.
   bool mSheetPrincipalRequired;
+  bool mCalcAllowsTypedArithmetic;
 
   // This enum helps us track whether we've unprefixed "display: -webkit-box"
   // (treating it as "display: flex") in an earlier declaration within a series
@@ -1831,6 +1891,7 @@ CSSParserImpl::CSSParserImpl()
     mInFailingSupportsRule(false),
     mSuppressErrors(false),
     mSheetPrincipalRequired(true),
+    mCalcAllowsTypedArithmetic(false),
     mWebkitBoxUnprefixState(eNotParsingDecls),
     mNextFree(nullptr)
 {
@@ -4005,8 +4066,12 @@ CSSParserImpl::ParseMediaQueryExpression(nsMediaQuery* aQuery)
   bool rv = false;
   switch (feature->mValueType) {
     case nsMediaFeature::eLength:
-      rv = ParseSingleTokenNonNegativeVariant(expr->mValue, VARIANT_LCALC,
-                                              nullptr);
+      {
+        AutoRestore<bool> autoRestore(mCalcAllowsTypedArithmetic);
+        mCalcAllowsTypedArithmetic = true;
+        rv = ParseSingleTokenNonNegativeVariant(expr->mValue, VARIANT_LCALC,
+                                                nullptr);
+      }
       break;
     case nsMediaFeature::eInteger:
     case nsMediaFeature::eBoolInteger:
@@ -14846,6 +14911,25 @@ CSSParserImpl::ParseCalc(nsCSSValue& aValue, uint32_t aVariantMask,
     if (!ParseCalcAdditiveExpression(arr->Item(0), resultVariantMask))
       break;
 
+    if (mCalcAllowsTypedArithmetic) {
+      int32_t exponent;
+      if (!GetCalcLengthTypedArithmeticExponent(arr->Item(0), exponent)) {
+        break;
+      }
+
+      if (aVariantMask & VARIANT_NUMBER) {
+        if (exponent == 0) {
+          resultVariantMask = VARIANT_NUMBER;
+        } else if (exponent == 1) {
+          resultVariantMask &= ~int32_t(VARIANT_NUMBER);
+        } else {
+          break;
+        }
+      } else if (exponent != 1) {
+        break;
+      }
+    }
+
     if (!ExpectSymbol(')', true))
       break;
 
@@ -14926,13 +15010,16 @@ CSSParserImpl::ParseCalcMultiplicativeExpression(nsCSSValue& aValue,
                                                  bool *aHadFinalWS)
 {
   MOZ_ASSERT(aVariantMask != 0, "unexpected variant mask");
+  bool allowTypedArithmetic = mCalcAllowsTypedArithmetic;
   bool gotValue = false; // already got the part with the unit
   bool afterDivision = false;
 
   nsCSSValue *storage = &aValue;
   for (;;) {
     uint32_t variantMask;
-    if (afterDivision || gotValue) {
+    if (allowTypedArithmetic) {
+      variantMask = aVariantMask | VARIANT_NUMBER;
+    } else if (afterDivision || gotValue) {
       variantMask = VARIANT_NUMBER;
     } else {
       variantMask = aVariantMask | VARIANT_NUMBER;
@@ -14953,7 +15040,7 @@ CSSParserImpl::ParseCalcMultiplicativeExpression(nsCSSValue& aValue,
       if (number == 0.0 && afterDivision)
         return false;
       storage->SetFloatValue(number, eCSSUnit_Number);
-    } else {
+    } else if (!allowTypedArithmetic) {
       gotValue = true;
 
       if (storage != &aValue) {
@@ -14975,7 +15062,10 @@ CSSParserImpl::ParseCalcMultiplicativeExpression(nsCSSValue& aValue,
     }
     nsCSSUnit unit;
     if (mToken.IsSymbol('*')) {
-      unit = gotValue ? eCSSUnit_Calc_Times_R : eCSSUnit_Calc_Times_L;
+      unit = allowTypedArithmetic
+               ? eCSSUnit_Calc_Times_R
+               : (gotValue ? eCSSUnit_Calc_Times_R
+                           : eCSSUnit_Calc_Times_L);
       afterDivision = false;
     } else if (mToken.IsSymbol('/')) {
       unit = eCSSUnit_Calc_Divided;
@@ -14994,6 +15084,23 @@ CSSParserImpl::ParseCalcMultiplicativeExpression(nsCSSValue& aValue,
 
   // Adjust aVariantMask (see comments above function) to reflect which
   // option we took.
+  if (allowTypedArithmetic) {
+    int32_t exponent;
+    if (!GetCalcLengthTypedArithmeticExponent(aValue, exponent)) {
+      return false;
+    }
+
+    if (aVariantMask & VARIANT_NUMBER) {
+      if (exponent == 0) {
+        aVariantMask = VARIANT_NUMBER;
+      } else {
+        aVariantMask &= ~int32_t(VARIANT_NUMBER);
+      }
+    }
+
+    return true;
+  }
+
   if (aVariantMask & VARIANT_NUMBER) {
     if (gotValue) {
       aVariantMask &= ~int32_t(VARIANT_NUMBER);

--- a/layout/style/nsCSSValue.cpp
+++ b/layout/style/nsCSSValue.cpp
@@ -1018,6 +1018,209 @@ private:
   nsCSSValue::Serialization mValueSerialization;
 };
 
+struct CSSValueReduceNumberCalcOps : public BasicFloatCalcOps,
+                                     public CSSValueInputCalcOps
+{
+  result_type ComputeLeafValue(const nsCSSValue& aValue)
+  {
+    MOZ_ASSERT(aValue.GetUnit() == eCSSUnit_Number, "unexpected unit");
+    return aValue.GetFloatValue();
+  }
+
+  float ComputeNumber(const nsCSSValue& aValue)
+  {
+    return css::ComputeCalc(aValue, *this);
+  }
+};
+
+struct CSSValueCalcLengthTerm {
+  nsCSSUnit mUnit;
+  float mValue;
+};
+
+struct CSSValueLengthPercentCalcAccumulator {
+  AutoTArray<CSSValueCalcLengthTerm, 8> mLengths;
+  float mPercent = 0.0f;
+  bool mSawPercent = false;
+
+  void AddLength(nsCSSUnit aUnit, float aValue)
+  {
+    for (CSSValueCalcLengthTerm& term : mLengths) {
+      if (term.mUnit == aUnit) {
+        term.mValue += aValue;
+        return;
+      }
+    }
+
+    CSSValueCalcLengthTerm& term = *mLengths.AppendElement();
+    term.mUnit = aUnit;
+    term.mValue = aValue;
+  }
+};
+
+static bool
+IsNearlyZero(float aValue)
+{
+  return aValue > -0.000001f && aValue < 0.000001f;
+}
+
+static bool
+ComputeCalcNumberValue(const nsCSSValue& aValue, float& aResult)
+{
+  if (aValue.GetUnit() == eCSSUnit_Number) {
+    aResult = aValue.GetFloatValue();
+    return true;
+  }
+
+  if (!aValue.IsCalcUnit()) {
+    return false;
+  }
+
+  CSSValueReduceNumberCalcOps ops;
+  aResult = css::ComputeCalc(aValue, ops);
+  return true;
+}
+
+static bool
+AccumulateCalcLengthPercentTerms(
+  const nsCSSValue& aValue,
+  float aScale,
+  CSSValueLengthPercentCalcAccumulator& aAccumulator)
+{
+  switch (aValue.GetUnit()) {
+    case eCSSUnit_Calc: {
+      const nsCSSValue::Array* array = aValue.GetArrayValue();
+      MOZ_ASSERT(array->Count() == 1, "unexpected length");
+      return AccumulateCalcLengthPercentTerms(array->Item(0), aScale,
+                                              aAccumulator);
+    }
+
+    case eCSSUnit_Calc_Plus:
+    case eCSSUnit_Calc_Minus: {
+      const nsCSSValue::Array* array = aValue.GetArrayValue();
+      MOZ_ASSERT(array->Count() == 2, "unexpected length");
+      if (!AccumulateCalcLengthPercentTerms(array->Item(0), aScale,
+                                            aAccumulator)) {
+        return false;
+      }
+      float rhsScale = aValue.GetUnit() == eCSSUnit_Calc_Plus
+                         ? aScale
+                         : -aScale;
+      return AccumulateCalcLengthPercentTerms(array->Item(1), rhsScale,
+                                              aAccumulator);
+    }
+
+    case eCSSUnit_Calc_Times_L:
+    case eCSSUnit_Calc_Times_R:
+    case eCSSUnit_Calc_Divided: {
+      const nsCSSValue::Array* array = aValue.GetArrayValue();
+      MOZ_ASSERT(array->Count() == 2, "unexpected length");
+
+      const nsCSSValue* value = &array->Item(0);
+      const nsCSSValue* factorValue = &array->Item(1);
+      if (aValue.GetUnit() == eCSSUnit_Calc_Times_L) {
+        value = &array->Item(1);
+        factorValue = &array->Item(0);
+      }
+
+      float factor;
+      if (!ComputeCalcNumberValue(*factorValue, factor)) {
+        return false;
+      }
+      if (aValue.GetUnit() == eCSSUnit_Calc_Divided) {
+        factor = 1.0f / factor;
+      }
+      return AccumulateCalcLengthPercentTerms(*value, aScale * factor,
+                                              aAccumulator);
+    }
+
+    case eCSSUnit_Percent:
+      aAccumulator.mSawPercent = true;
+      aAccumulator.mPercent += aScale * aValue.GetPercentValue();
+      return true;
+
+    default:
+      break;
+  }
+
+  if (aValue.IsLengthUnit()) {
+    aAccumulator.AddLength(aValue.GetUnit(), aScale * aValue.GetFloatValue());
+    return true;
+  }
+
+  return false;
+}
+
+static void
+AppendSerializedCalcLeafValue(nsCSSPropertyID aProperty,
+                              nsAString& aResult,
+                              nsCSSValue::Serialization aSerialization,
+                              nsCSSUnit aUnit,
+                              float aValue)
+{
+  nsCSSValue value;
+  if (aUnit == eCSSUnit_Percent) {
+    value.SetPercentValue(aValue);
+  } else {
+    value.SetFloatValue(aValue, aUnit);
+  }
+  value.AppendToString(aProperty, aResult, aSerialization);
+}
+
+static bool
+AppendNormalizedLengthPercentCalcToString(
+  const nsCSSValue& aValue,
+  nsCSSPropertyID aProperty,
+  nsAString& aResult,
+  nsCSSValue::Serialization aSerialization)
+{
+  CSSValueLengthPercentCalcAccumulator accumulator;
+  if (!AccumulateCalcLengthPercentTerms(aValue, 1.0f, accumulator)) {
+    return false;
+  }
+
+  AutoTArray<CSSValueCalcLengthTerm, 9> serializedTerms;
+  if (!IsNearlyZero(accumulator.mPercent) || accumulator.mSawPercent) {
+    CSSValueCalcLengthTerm& term = *serializedTerms.AppendElement();
+    term.mUnit = eCSSUnit_Percent;
+    term.mValue = accumulator.mPercent;
+  }
+
+  for (const CSSValueCalcLengthTerm& term : accumulator.mLengths) {
+    if (IsNearlyZero(term.mValue)) {
+      continue;
+    }
+    serializedTerms.AppendElement(term);
+  }
+
+  if (serializedTerms.IsEmpty()) {
+    CSSValueCalcLengthTerm& term = *serializedTerms.AppendElement();
+    term.mUnit = accumulator.mSawPercent ? eCSSUnit_Percent : eCSSUnit_Pixel;
+    term.mValue = 0.0f;
+  }
+
+  aResult.AppendLiteral("calc(");
+  AppendSerializedCalcLeafValue(aProperty, aResult, aSerialization,
+                                serializedTerms[0].mUnit,
+                                serializedTerms[0].mValue);
+
+  for (uint32_t i = 1; i < serializedTerms.Length(); ++i) {
+    const CSSValueCalcLengthTerm& term = serializedTerms[i];
+    if (term.mValue < 0.0f) {
+      aResult.AppendLiteral(" - ");
+      AppendSerializedCalcLeafValue(aProperty, aResult, aSerialization,
+                                    term.mUnit, -term.mValue);
+    } else {
+      aResult.AppendLiteral(" + ");
+      AppendSerializedCalcLeafValue(aProperty, aResult, aSerialization,
+                                    term.mUnit, term.mValue);
+    }
+  }
+
+  aResult.Append(')');
+  return true;
+}
+
 } // namespace
 
 void
@@ -1474,8 +1677,11 @@ nsCSSValue::AppendToString(nsCSSPropertyID aProperty, nsAString& aResult,
   }
   else if (IsCalcUnit()) {
     MOZ_ASSERT(GetUnit() == eCSSUnit_Calc, "unexpected unit");
-    CSSValueSerializeCalcOps ops(aProperty, aResult, aSerialization);
-    css::SerializeCalc(*this, ops);
+    if (!AppendNormalizedLengthPercentCalcToString(*this, aProperty, aResult,
+                                                   aSerialization)) {
+      CSSValueSerializeCalcOps ops(aProperty, aResult, aSerialization);
+      css::SerializeCalc(*this, ops);
+    }
   }
   else if (eCSSUnit_Integer == unit) {
     aResult.AppendInt(GetIntValue(), 10);

--- a/layout/style/nsCSSValue.cpp
+++ b/layout/style/nsCSSValue.cpp
@@ -6,6 +6,7 @@
 /* representation of simple property values within CSS declarations */
 
 #include "mozilla/ArrayUtils.h"
+#include "mozilla/FloatingPoint.h"
 
 #include "nsCSSValue.h"
 
@@ -28,6 +29,25 @@
 
 using namespace mozilla;
 using namespace mozilla::css;
+
+static void
+AppendSerializedCSSFloat(float aValue, nsAString& aResult)
+{
+  if (mozilla::IsNaN(aValue)) {
+    aResult.AppendLiteral("NaN");
+    return;
+  }
+
+  if (mozilla::IsInfinite(aValue)) {
+    if (aValue < 0.0f) {
+      aResult.Append('-');
+    }
+    aResult.AppendLiteral("infinity");
+    return;
+  }
+
+  aResult.AppendFloat(aValue);
+}
 
 static bool
 IsLocalRefURL(nsStringBuffer* aString)
@@ -67,7 +87,6 @@ nsCSSValue::nsCSSValue(float aValue, nsCSSUnit aUnit)
   MOZ_ASSERT(eCSSUnit_Percent <= aUnit, "not a float value");
   if (eCSSUnit_Percent <= aUnit) {
     mValue.mFloat = aValue;
-    MOZ_ASSERT(!mozilla::IsNaN(mValue.mFloat));
   }
   else {
     mUnit = eCSSUnit_Null;
@@ -146,7 +165,6 @@ nsCSSValue::nsCSSValue(const nsCSSValue& aCopy)
   }
   else if (eCSSUnit_Percent <= mUnit) {
     mValue.mFloat = aCopy.mValue.mFloat;
-    MOZ_ASSERT(!mozilla::IsNaN(mValue.mFloat));
   }
   else if (UnitHasStringValue()) {
     mValue.mString = aCopy.mValue.mString;
@@ -483,7 +501,6 @@ void nsCSSValue::SetPercentValue(float aValue)
   Reset();
   mUnit = eCSSUnit_Percent;
   mValue.mFloat = aValue;
-  MOZ_ASSERT(!mozilla::IsNaN(mValue.mFloat));
 }
 
 void nsCSSValue::SetFloatValue(float aValue, nsCSSUnit aUnit)
@@ -493,7 +510,6 @@ void nsCSSValue::SetFloatValue(float aValue, nsCSSUnit aUnit)
   if (IsFloatUnit(aUnit)) {
     mUnit = aUnit;
     mValue.mFloat = aValue;
-    MOZ_ASSERT(!mozilla::IsNaN(mValue.mFloat));
   }
 }
 
@@ -1973,10 +1989,10 @@ nsCSSValue::AppendToString(nsCSSPropertyID aProperty, nsAString& aResult,
     aResult.Append(')');
   }
   else if (eCSSUnit_Percent == unit) {
-    aResult.AppendFloat(GetPercentValue() * 100.0f);
+    AppendSerializedCSSFloat(GetPercentValue() * 100.0f, aResult);
   }
   else if (eCSSUnit_Percent < unit) {  // length unit
-    aResult.AppendFloat(GetFloatValue());
+    AppendSerializedCSSFloat(GetFloatValue(), aResult);
   }
   else if (eCSSUnit_Gradient == unit) {
     nsCSSValueGradient* gradient = GetGradientValue();

--- a/layout/style/nsCSSValue.h
+++ b/layout/style/nsCSSValue.h
@@ -773,7 +773,6 @@ public:
   float GetFloatValue() const
   {
     MOZ_ASSERT(eCSSUnit_Number <= mUnit, "not a float value");
-    MOZ_ASSERT(!mozilla::IsNaN(mValue.mFloat));
     return mValue.mFloat;
   }
 
@@ -2026,4 +2025,3 @@ private:
 } // namespace mozilla
 
 #endif /* nsCSSValue_h___ */
-

--- a/layout/style/nsRuleNode.cpp
+++ b/layout/style/nsRuleNode.cpp
@@ -13,6 +13,7 @@
 #include "mozilla/ArrayUtils.h"
 #include "mozilla/Assertions.h"
 #include "mozilla/DebugOnly.h"
+#include "mozilla/FloatingPoint.h"
 #include "mozilla/Function.h"
 #include "mozilla/dom/AnimationEffectReadOnlyBinding.h" // for PlaybackDirection
 #include "mozilla/Likely.h"
@@ -1774,6 +1775,17 @@ SetValue(const nsCSSValue& aValue, FieldT& aField,
 #define SETFCT_UNSET_INHERIT  0x00400000
 #define SETFCT_UNSET_INITIAL  0x00800000
 
+struct RuleNodeReduceNumberCalcOps : public css::BasicFloatCalcOps,
+                                     public css::CSSValueInputCalcOps,
+                                     public css::NumbersAlreadyNormalizedOps
+{
+  result_type ComputeLeafValue(const nsCSSValue& aValue)
+  {
+    MOZ_ASSERT(aValue.GetUnit() == eCSSUnit_Number, "unexpected unit");
+    return aValue.GetFloatValue();
+  }
+};
+
 static void
 SetFactor(const nsCSSValue& aValue, float& aField, RuleNodeCacheConditions& aConditions,
           float aParentValue, float aInitialValue, uint32_t aFlags = 0)
@@ -1784,6 +1796,9 @@ SetFactor(const nsCSSValue& aValue, float& aField, RuleNodeCacheConditions& aCon
 
   case eCSSUnit_Number:
     aField = aValue.GetFloatValue();
+    if (mozilla::IsNaN(aField)) {
+      aField = 0.0f;
+    }
     if (aFlags & SETFCT_POSITIVE) {
       NS_ASSERTION(aField >= 0.0f, "negative value for positive-only property");
       if (aField < 0.0f) {
@@ -1799,6 +1814,29 @@ SetFactor(const nsCSSValue& aValue, float& aField, RuleNodeCacheConditions& aCon
       }
     }
     return;
+
+  case eCSSUnit_Calc: {
+    RuleNodeReduceNumberCalcOps ops;
+    aField = css::ComputeCalc(aValue, ops);
+    if (mozilla::IsNaN(aField)) {
+      aField = 0.0f;
+    }
+    if (aFlags & SETFCT_POSITIVE) {
+      NS_ASSERTION(aField >= 0.0f, "negative value for positive-only property");
+      if (aField < 0.0f) {
+        aField = 0.0f;
+      }
+    }
+    if (aFlags & SETFCT_OPACITY) {
+      if (aField < 0.0f) {
+        aField = 0.0f;
+      }
+      if (aField > 1.0f) {
+        aField = 1.0f;
+      }
+    }
+    return;
+  }
 
   case eCSSUnit_Inherit:
     aConditions.SetUncacheable();

--- a/layout/style/test/mochitest.ini
+++ b/layout/style/test/mochitest.ini
@@ -156,6 +156,8 @@ support-files = file_bug1089417_iframe.html
 [test_clip-path_polygon.html]
 [test_compute_data_with_start_struct.html]
 [test_computed_style.html]
+[test_calc_numeric_types.html]
+prefs = layout.css.filters.enabled=true
 [test_computed_style_min_size_auto.html]
 [test_computed_style_no_pseudo.html]
 [test_computed_style_prefs.html]

--- a/layout/style/test/property_database.js
+++ b/layout/style/test/property_database.js
@@ -122,6 +122,8 @@ var validGradientAndElementValues = [
   "linear-gradient(10deg, red, blue)",
   "linear-gradient(1turn, red, blue)",
   "linear-gradient(.414rad, red, blue)",
+  "linear-gradient(calc(90deg / 2), red, blue)",
+  "linear-gradient(calc(calc(0.25turn) + 45deg), red, blue)",
   "linear-gradient(90deg in srgb, yellow, purple)",
   "linear-gradient(90deg in hsl, yellow, purple)",
   "linear-gradient(90deg in lch, yellow, purple)",
@@ -1005,7 +1007,8 @@ var gCSSProperties = {
     inherited: false,
     type: CSS_TYPE_LONGHAND,
     initial_values: ["0s", "0ms"],
-    other_values: ["1s", "250ms", "-100ms", "-1s", "1s, 250ms, 2.3s"],
+    other_values: ["1s", "250ms", "-100ms", "-1s", "1s, 250ms, 2.3s",
+                   "calc(250ms - 0.5s)", "calc(calc(500ms) - 250ms)"],
     invalid_values: ["0", "0px"],
   },
   "animation-direction": {
@@ -1030,7 +1033,8 @@ var gCSSProperties = {
     inherited: false,
     type: CSS_TYPE_LONGHAND,
     initial_values: ["0s", "0ms"],
-    other_values: ["1s", "250ms", "1s, 250ms, 2.3s"],
+    other_values: ["1s", "250ms", "1s, 250ms, 2.3s",
+                   "calc(calc(0.25s) + 250ms)"],
     invalid_values: ["0", "0px", "-1ms", "-2s"],
   },
   "animation-fill-mode": {
@@ -2854,6 +2858,9 @@ var gCSSProperties = {
       "translate(calc(5px - 10% * 3))",
       "translate(calc(5px - 3 * 10%), 50px)",
       "translate(-50px, calc(5px - 10% * 3))",
+      "rotate(calc(45deg + 45deg))",
+      "rotate(calc(calc(0.125turn) + 45deg))",
+      "scale(calc(1 + 0.5))",
       "translatez(1px)",
       "translatez(4em)",
       "translatez(-4px)",
@@ -5572,7 +5579,8 @@ var gCSSProperties = {
       "3e+0",
       "3e-0",
     ],
-    other_values: ["0", "0.4", "0.0000", "-3", "3e-1", "-100%", "50%"],
+    other_values: ["0", "0.4", "0.0000", "-3", "3e-1", "-100%", "50%",
+                   "calc(25% * 2)", "calc(calc(0.25) + 0.25)"],
     invalid_values: ["0px", "1px"],
   },
   "-moz-orient": {
@@ -6401,7 +6409,8 @@ var gCSSProperties = {
     inherited: false,
     type: CSS_TYPE_LONGHAND,
     initial_values: ["0s", "0ms"],
-    other_values: ["1s", "250ms", "-100ms", "-1s", "1s, 250ms, 2.3s"],
+    other_values: ["1s", "250ms", "-100ms", "-1s", "1s, 250ms, 2.3s",
+                   "calc(250ms - 0.5s)", "calc(calc(500ms) - 250ms)"],
     invalid_values: ["0", "0px"],
   },
   "transition-duration": {
@@ -6409,7 +6418,8 @@ var gCSSProperties = {
     inherited: false,
     type: CSS_TYPE_LONGHAND,
     initial_values: ["0s", "0ms"],
-    other_values: ["1s", "250ms", "1s, 250ms, 2.3s"],
+    other_values: ["1s", "250ms", "1s, 250ms, 2.3s",
+                   "calc(calc(0.25s) + 250ms)"],
     invalid_values: ["0", "0px", "-1ms", "-2s"],
   },
   "transition-property": {
@@ -6773,7 +6783,7 @@ var gCSSProperties = {
     type: CSS_TYPE_LONGHAND,
     /* XXX requires position */
     initial_values: ["auto"],
-    other_values: ["0", "3", "-7000", "12000"],
+    other_values: ["0", "3", "-7000", "12000", "calc(2.5)"],
     invalid_values: ["3.0", "17.5", "3e1"],
   },
   "clip-path": {
@@ -7633,7 +7643,8 @@ var gCSSProperties = {
     inherited: false,
     type: CSS_TYPE_LONGHAND,
     initial_values: ["0"],
-    other_values: ["1", "99999", "-1", "-50"],
+    other_values: ["1", "99999", "-1", "-50", "calc(1.5)",
+                   "calc(calc(-2) + 1)"],
     invalid_values: ["0px", "1.0", "1.", "1%", "0.2", "3em", "stretch"],
   },
 
@@ -9293,6 +9304,8 @@ if (IsCSSPropertyPrefEnabled("layout.css.filters.enabled")) {
       "brightness(2)",
       "brightness(350%)",
       "brightness(4.567)",
+      "brightness(calc(25% * 2))",
+      "brightness(calc(calc(0.25) + 0.25))",
 
       "contrast(0)",
       "contrast(50%)",
@@ -9337,6 +9350,7 @@ if (IsCSSPropertyPrefEnabled("layout.css.filters.enabled")) {
       "hue-rotate(-1.6rad)",
       "hue-rotate(0.5turn)",
       "hue-rotate(-2turn)",
+      "hue-rotate(calc(90deg + 0.125turn))",
 
       "invert(0)",
       "invert(50%)",

--- a/layout/style/test/test_calc_numeric_types.html
+++ b/layout/style/test/test_calc_numeric_types.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Test calc() numeric type support</title>
+    <script src="/tests/SimpleTest/SimpleTest.js"></script>
+    <link rel="stylesheet" href="/tests/SimpleTest/test.css">
+  </head>
+  <body>
+    <div id="display"></div>
+    <pre id="test">
+<script>
+"use strict";
+
+function appendTestNode(tag = "div") {
+  const node = document.createElement(tag);
+  document.getElementById("display").appendChild(node);
+  return node;
+}
+
+function parse2dMatrix(transformValue) {
+  const match = /^matrix\(([^)]+)\)$/.exec(transformValue);
+  ok(match, `expected a 2d matrix, got "${transformValue}"`);
+  return match[1].split(",").map(value => parseFloat(value.trim()));
+}
+
+(function testNestedCalcLengthPercentage() {
+  const container = appendTestNode();
+  container.style.width = "200px";
+  container.style.position = "absolute";
+
+  const child = document.createElement("div");
+  child.style.width = "calc(calc(50% + 10px) - calc(5px + 10%))";
+  container.appendChild(child);
+
+  is(getComputedStyle(child).width, "85px",
+     "nested calc() should resolve length-percentage expressions correctly");
+
+  container.remove();
+})();
+
+(function testTimeCalc() {
+  const div = appendTestNode();
+  div.style.transitionDuration = "calc(calc(0.25s) + 250ms)";
+  div.style.animationDelay = "calc(250ms - 0.5s)";
+
+  is(getComputedStyle(div).transitionDuration, "0.5s",
+     "transition-duration should accept calc() time values");
+  is(getComputedStyle(div).animationDelay, "-0.25s",
+     "animation-delay should accept calc() time values");
+
+  div.remove();
+})();
+
+(function testNumericAndIntegerCalc() {
+  const div = appendTestNode();
+  div.style.opacity = "calc(25% * 2)";
+  div.style.order = "calc(1.5)";
+  div.style.zIndex = "calc(2.5)";
+
+  is(getComputedStyle(div).opacity, "0.5",
+     "opacity should accept calc() number/percent values");
+  is(getComputedStyle(div).order, "2",
+     "order should round calc() results to the nearest integer");
+  is(getComputedStyle(div).zIndex, "3",
+     "z-index should round calc() results to the nearest integer");
+
+  div.remove();
+})();
+
+(function testAngleAndNumberCalcInFunctions() {
+  const div = appendTestNode();
+  div.style.transform = "rotate(calc(45deg + 45deg)) scale(calc(1 + 0.5))";
+  div.style.filter = "hue-rotate(calc(90deg + 0.125turn)) brightness(calc(0.25 + 0.25))";
+  div.style.backgroundImage = "linear-gradient(calc(90deg / 2), red, blue)";
+
+  ok(div.style.filter !== "",
+     "filter should accept calc() in angle and number function arguments");
+  ok(div.style.backgroundImage !== "",
+     "gradients should accept calc() in angle arguments");
+
+  const matrix = parse2dMatrix(getComputedStyle(div).transform);
+  ok(Math.abs(matrix[0]) < 1e-6, "rotate(calc()) should zero out the xx entry");
+  ok(Math.abs(matrix[1] - 1.5) < 1e-6, "scale(calc()) should affect the xy entry");
+  ok(Math.abs(matrix[2] + 1.5) < 1e-6, "scale(calc()) should affect the yx entry");
+  ok(Math.abs(matrix[3]) < 1e-6, "rotate(calc()) should zero out the yy entry");
+
+  div.remove();
+})();
+</script>
+    </pre>
+  </body>
+</html>

--- a/layout/style/test/test_calc_numeric_types.html
+++ b/layout/style/test/test_calc_numeric_types.html
@@ -87,6 +87,25 @@ function parse2dMatrix(transformValue) {
 
   div.remove();
 })();
+
+(function testNestedCalcSpecifiedSerialization() {
+  const div = appendTestNode();
+  const cases = [
+    ["left", "calc(calc(20px) + calc(80px))", "calc(100px)"],
+    ["left", "calc(calc(2) * calc(50px))", "calc(100px)"],
+    ["left", "calc(calc(150px * 2 / 3))", "calc(100px)"],
+    ["left", "calc(50px + calc(40%))", "calc(40% + 50px)"],
+    ["border", "calc(calc(10px)) solid pink", "calc(10px) solid pink"],
+  ];
+
+  for (const [property, input, expected] of cases) {
+    div.style.setProperty(property, input, "");
+    is(div.style.getPropertyValue(property), expected,
+       `${property} should canonicalize nested calc() serialization`);
+  }
+
+  div.remove();
+})();
 </script>
     </pre>
   </body>

--- a/layout/style/test/test_calc_numeric_types.html
+++ b/layout/style/test/test_calc_numeric_types.html
@@ -106,6 +106,44 @@ function parse2dMatrix(transformValue) {
 
   div.remove();
 })();
+
+(function testSpecialNumberCalcSpecifiedSerialization() {
+  const div = appendTestNode();
+  const cases = [
+    ["calc(NaN)", "calc(NaN)"],
+    ["calc(infinity)", "calc(infinity)"],
+    ["calc(-infinity)", "calc(-infinity)"],
+    ["calc(1 * NaN)", "calc(NaN)"],
+    ["calc(1 * infinity / infinity)", "calc(NaN)"],
+    ["calc(1 * 0 * infinity)", "calc(NaN)"],
+    ["calc(1 * (infinity + -infinity))", "calc(NaN)"],
+    ["calc(1 * (infinity - infinity))", "calc(NaN)"],
+    ["calc(1 * infinity)", "calc(infinity)"],
+    ["calc(1 * -infinity)", "calc(-infinity)"],
+    ["calc(1 * 1/infinity)", "calc(0)"],
+    ["calc(1 * infinity * infinity)", "calc(infinity)"],
+    ["calc(1 * max(INFinity*3, 0))", "calc(infinity)"],
+    ["calc(1 * min(inFInity*4, 0))", "calc(0)"],
+    ["calc(1 * max(nAn*2, 0))", "calc(NaN)"],
+    ["calc(1 * clamp(-INFINITY*20, 0, infiniTY*10))", "calc(0)"],
+    ["calc(1 * max(NaN, min(0,10)))", "calc(NaN)"],
+    ["calc(1 * clamp(NaN, 0, 10))", "calc(NaN)"],
+    ["calc(1 * max(0, min(10, NaN)))", "calc(NaN)"],
+    ["calc(1 * clamp(0, 10, NaN))", "calc(NaN)"],
+    ["calc(1 * max(0, min(NaN, 10)))", "calc(NaN)"],
+    ["calc(1 * clamp(0, NaN, 10))", "calc(NaN)"],
+    ["calc(1 * clamp(-Infinity, 0, infinity))", "calc(0)"],
+    ["calc(1 * clamp(-inFinity, infinity, 10))", "calc(10)"],
+  ];
+
+  for (const [input, expected] of cases) {
+    div.style.setProperty("opacity", input, "");
+    is(div.style.getPropertyValue("opacity"), expected,
+       `opacity should serialize ${input} as ${expected}`);
+  }
+
+  div.remove();
+})();
 </script>
     </pre>
   </body>

--- a/layout/style/test/test_media_queries.html
+++ b/layout/style/test/test_media_queries.html
@@ -237,6 +237,7 @@ function run() {
     expression_should_be_parseable(feature + ": 0");
     expression_should_be_parseable(feature + ": 0px");
     expression_should_be_parseable(feature + ": 0em");
+    expression_should_be_parseable(feature + ": calc(0px + 0em)");
     expression_should_be_parseable(feature + ": -0");
     expression_should_be_parseable("min-" + feature + ": -0");
     expression_should_be_parseable("max-" + feature + ": -0");
@@ -244,6 +245,7 @@ function run() {
     expression_should_be_parseable(feature + ": 1px");
     expression_should_be_parseable(feature + ": 0.001mm");
     expression_should_be_parseable(feature + ": 100000px");
+    expression_should_not_be_parseable(feature + ": calc(1px + 1%)");
     expression_should_not_be_parseable(feature + ": -1px");
     expression_should_not_be_parseable("min-" + feature + ": -1px");
     expression_should_not_be_parseable("max-" + feature + ": -1px");
@@ -263,8 +265,9 @@ function run() {
 
   var content_div = document.getElementById("content");
   content_div.style.font = "initial";
-  var em_size =
-    getComputedStyle(content_div, "").fontSize.match(/^(\d+)px$/)[1];
+  var em_size = parseFloat(
+    getComputedStyle(content_div, "").fontSize.match(/^(\d+)px$/)[1]
+  );
 
   // in this test, assume the common underlying implementation is correct
   var width_val = 117; // pick two not-too-round numbers
@@ -282,7 +285,11 @@ function run() {
   for (feature in features) {
     var value = features[feature];
     should_apply("all and (" + feature + ": " + value + "px)");
+    should_apply("all and (" + feature + ": calc(" +
+                 (value - em_size) + "px + 1em))");
     should_not_apply("all and (" + feature + ": " + (value + 1) + "px)");
+    should_not_apply("all and (" + feature + ": calc(" +
+                     (value - em_size + 1) + "px + 1em))");
     should_not_apply("all and (" + feature + ": " + (value - 1) + "px)");
     should_apply("all and (min-" + feature + ": " + value + "px)");
     should_not_apply("all and (min-" + feature + ": " + (value + 1) + "px)");

--- a/layout/style/test/test_media_queries.html
+++ b/layout/style/test/test_media_queries.html
@@ -316,6 +316,21 @@ function run() {
   }
 
   change_state(function() {
+    iframe_style.width = "100px";
+    iframe_style.height = "10px";
+  });
+  should_apply("all and (width: calc(100px / 1em * 1em))");
+  should_apply("all and (width: calc((50vh * 5em) / 4px))");
+  should_apply("all and (width: calc(10vw / 10px * 1000vh))");
+  should_apply("all and (width: calc(8000vh * 1vw / 1em * 8px / 40vh))");
+  should_not_apply("all and (width: calc(100px / 1em * 2em))");
+
+  change_state(function() {
+    iframe_style.width = width_val + "px";
+    iframe_style.height = height_val + "px";
+  });
+
+  change_state(function() {
     iframe_style.width = "0";
   });
   should_apply("all and (height)");


### PR DESCRIPTION
We have calc but it's super outdated. I modernized it so it's mostly spec compliant.

  - Broader property support in platform/layout/style/nsCSSParser.cpp:171:
    calc() now parses and reduces correctly for number, integer, opacity, angle, time, and frequency, not just length/percent cases.
  - Nested calc() support:
    nested calls like calc(calc(...)), additive nesting, and multiplicative nesting now parse and serialize correctly across those numeric types.
  - Canonical nested serialization in platform/layout/style/nsCSSValue.cpp:1171:
    nested expressions normalize to spec-like output such as calc(100px) and calc(40% + 50px) instead of preserving unnecessary inner wrappers.
  - Media-query calc() support:
    media features now accept calc() lengths instead of rejecting them as not all.
  - Typed arithmetic for media queries in platform/layout/style/CSSStyleSheet.cpp:164 and platform/layout/style/nsCSSParser.cpp:14893:
    expressions like calc(100px / 1em * 1em) and calc(50vh * 5em / 4px) now parse and evaluate for media-query matching.
  - Special numeric values in calc():
    NaN, infinity, and -infinity now parse inside numeric calc() expressions, including case-insensitive forms.
  - Numeric math functions inside calc():
    numeric min(), max(), and clamp() are now accepted and reduced in the special-number path.
  - Correct specified-value serialization for special numbers in platform/layout/style/nsCSSValue.cpp:30:
    values serialize as calc(NaN), calc(infinity), calc(-infinity), calc(0), etc., which was the missing calc-infinity-nan-serialize-number.html behavior.
  - Safe computed-style handling in platform/layout/style/nsRuleNode.cpp:1778:
    factor-like properties can now resolve calc-number trees without letting NaN poison computed values.
  - Test coverage:
    expanded platform/layout/style/test/test_calc_numeric_types.html:27, platform/layout/style/test/test_media_queries.html:240, and platform/layout/style/test/property_database.js:5583 for nested calc, numeric types, media queries, filters, transforms,
    gradients, and special-number serialization.


I found at least three sites on the pale moon forum that this fixes.

https://www.raiplay.it/
https://www.incavo.com/
https://www.fmatz.com/Vuetify-Card-Work/chk_forms-poc.html